### PR TITLE
If no date given, don't display an empty date

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,7 +3,9 @@
 {{- if and (isset .Params "justify") (eq .Params.justify true) -}} {{- $justify = true -}} {{- end -}}
 <section class="article-header" {{- if $justify -}}style="text-align: justify;" {{- end -}}>
 <h1>{{- .Title | safeHTML -}}</h1>
+{{- if .Date -}}
 <p class="article-date">{{- .Date.Format "2006-01-02" -}}</p>
+{{- end -}}
 </section>
 <article class="markdown-body" {{- if $justify -}}style="text-align: justify;" {{- end -}}>
 {{- .Content -}}


### PR DESCRIPTION
Currently, files with no date display "0001-01-01", which is both uninformative and wrong. It would be better if they didn't show a date at all, such as for about pages.