### PR TITLE
Enable toggling of full RSS feed through param.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ dateFormat = "Monday, January 2, 2006"  # if unset, default is "2006-01-02"
 logo = ""  # if you have a logo png
 slogan = "100% JavaScript-free"
 license = ""  # CC License
+fullRss = false # Puts entire HTML post into rss 'description' tag. If unset, default is false.
 
 [params.comments]
 enable = false  # En/Disable comments globally, default: false. You can always enable comments on per page.
@@ -221,8 +222,8 @@ You can relayout copyright like this:
 {{- $copyright := . -}}
 <div style="display:flex; flex-direction:row; flex-wrap:wrap; justify-content:space-between;">
 <p style="flex-shrink: 0;">{{- $copyright -}}</p>
-<p><span>Powered by </span><a 
-    href="https://gohugo.io" target="_blank">Hugo</a><span> and the </span><a 
+<p><span>Powered by </span><a
+    href="https://gohugo.io" target="_blank">Hugo</a><span> and the </span><a
     href="https://themes.gohugo.io/hugo-notepadium/" target="_blank">Notepadium</a></p>
 </div>
 ```
@@ -291,7 +292,7 @@ An example navigation-items.html:
     {{- range $nav.custom -}}
         {{- $url := .url | safeURL -}}
         {{- if strings.HasPrefix $url "/" -}}{{- $url = $url | relLangURL -}}{{- end -}}
-        <a class="nav item" href="{{- $url -}}" 
+        <a class="nav item" href="{{- $url -}}"
             {{- if strings.HasPrefix $url "http" -}}target="_blank"
             {{- end -}}>{{- .title -}}</a>
     {{- end -}}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -21,6 +21,9 @@
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .RelPermalink }}</guid>
       <description>{{ .Summary | html }}</description>
+      {{ if and (isset .Site.Params "fullrss") (.Site.Params.fullrss) }}
+      <content:encoded>{{ `<![CDATA[` | safeHTML }}{{ .Content | safeHTML }}{{ `]]>` | safeHTML }}</content:encoded>
+      {{ end }}
     </item>
     {{ end }}
   </channel>


### PR DESCRIPTION
When setting up an RSS + email integration for a mailing list, the RSS feed needs to contain the HTML of the post in the rss 'description' field.

This commit adds a 'fullRss' option that allows users to enable this.

Links:

- https://validator.w3.org/feed/docs/rss2.html
- https://backendology.com/2018/08/31/hugo-newsletter/