### PR TITLE
Set robots meta tag from page front matter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,17 @@ date = 2020-05-01T22:20:36+08:00
 +++
 ```
 
+### Set robots meta tag
+
+In the front matter of any page, you can selectively enable the `robots` meta tag
+and define its content:
+
+```toml
+robots = "noindex,nofollow"
+```
+
+If `noindex` is included, that page will also be hidden in `sitemap.xml`.
+
 ## Thanks
 
 - [**Hugo**](https://gohugo.io/)

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,4 +20,7 @@
 {{- partial "style.html" . -}}
 {{- partial "rss-feed.html" . -}}
 {{- partial "twitter-card.html" . -}}
+{{- if .Params.Robots -}}
+<meta name="robots" content="{{ .Params.robots }}" />
+{{- end -}}
 {{- partial "head-extra.html" . -}}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{- range .Data.Pages -}}
+  {{- if not (in .Params.Robots "noindex") -}}
   <url>
     <loc>{{- .Permalink -}}</loc>{{- if not .Lastmod.IsZero -}}
     <lastmod>{{- safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) -}}</lastmod>{{- end -}}{{- with .Sitemap.ChangeFreq -}}
@@ -18,5 +19,6 @@
                 href="{{- .Permalink -}}"
                 />{{- end -}}
   </url>
+  {{- end -}}
   {{- end -}}
 </urlset>


### PR DESCRIPTION
I needed this, and found it easy enough to add in a general and non-destructive way.