### PR TITLE
Pick up CSS assets from page front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,22 +234,37 @@ You can relayout copyright like this:
 
 ### Custom CSS
 
+Specify additional CSS files in the site config:
+
 ```toml
 [params.assets]
 css = ["css/font.css", "css/color.css", "css/layout.scss"]  # *.css/scss/sass
 ```
 
-On user-side:
+Or in the page front matter:
+
+```Markdown
+---
+title: "My Page"
+assets:
+  css: ["css/more-color.css"]
+---
+
+My colorful page
+```
+
+Put the files here:
 
 ```
 .
 └── assets
     └── css
         ├── color.css
+        ├── more-color.css
         └── font.css
 ```
 
-`color.css` and `font.css` will be bundled into `core.css`.
+All referenced files -- here, `color.css` and `font.css` for all pages, and `more-color.css` for some pages -- will be bundled into `core.css`. Note that this will create a separate CSS file for each combination of included assets.
 
 ### Custom JS
 

--- a/layouts/partials/custom-css.html
+++ b/layouts/partials/custom-css.html
@@ -1,5 +1,7 @@
 {{- $css := "" -}}
-{{- range site.Params.assets.css -}}
+{{- $cssPageAssets := .Params.assets.css | default (slice ) -}}
+{{- $cssAssets := union site.Params.assets.css $cssPageAssets -}}
+{{- range $cssAssets -}}
   {{- $customCSS := resources.Get . -}}
   {{- if $customCSS -}}
     {{- $scss := false -}}


### PR DESCRIPTION
This allows us to include some CSS only on some pages.
Conventions are the same as for site config.

### Example

```md
---
title: "Impressum"
lastMod: 2020-05-10T18:00:00+02:00
robots: "noindex"
assets:
  css: ["css/privacy_hacks.css"]
---
```