### PR TITLE
Use full URL for iconfont

### DIFF
--- a/assets/css/iconfont.css
+++ b/assets/css/iconfont.css
@@ -2,7 +2,7 @@
   font-family: "iconfont";
   {{- $url := "https://fontbuf.com/assets/fonts/iconfont.ttf?t=1588390362269" -}}
   {{- if site.Params.internalIconfont -}}
-    {{- $url = "/assets/font/iconfont.ttf?t=1588390362269" -}}
+    {{- $url = site.BaseURL | printf "%s/assets/font/iconfont.ttf?t=1588390362269" -}}
   {{- end -}}
   src: url('{{- $url -}}') format('truetype');
 }


### PR DESCRIPTION
Use `baseURL` explicitly to circumvent absolute paths failing if the site lives in a subfolder.

As an alternative, `../assets/...` would work but relies on where exactly the CSS ends up being deployed; also, @cntrump rejected relative asset paths earlier.