### PR TITLE
i18n: Add Portuguese language support (Brazil and Portugal)

### DIFF
--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -1,0 +1,12 @@
+[edited]
+other = " • Editado em %s"
+
+[readingTime]
+one = " • Um minuto de leitura"
+other = " • {{ .Count }} minutos de leitura"
+
+[Categories]
+other = "Categorias"
+
+[Tags]
+other = "Tags"

--- a/i18n/pt-pt.toml
+++ b/i18n/pt-pt.toml
@@ -1,0 +1,12 @@
+[edited]
+other = " • Editado em %s"
+
+[readingTime]
+one = " • Um minuto de leitura"
+other = " • {{ .Count }} minutos de leitura"
+
+[Categories]
+other = "Categorias"
+
+[Tags]
+other = "Tags"


### PR DESCRIPTION
Add support to Portuguese (Brazil and Portugal), so one can use `defaultContentLanguage = "pt-br"` or `defaultContentLanguage = "pt-pt"`.