### PR TITLE
Add noopener attribute to external links

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -2,4 +2,4 @@
 {{- $text := .Text | safeHTML -}}
 <a href="{{- $url -}}" 
 {{- with .Title -}}title="{{- . -}}"{{- end -}} 
-{{- if strings.HasPrefix $url "http" -}}target="_blank"{{- end -}}>{{- $text -}}</a>
+{{- if strings.HasPrefix $url "http" -}}target="_blank" rel="noopener noreferrer"{{- end -}}>{{- $text -}}</a>

--- a/layouts/partials/article-author.html
+++ b/layouts/partials/article-author.html
@@ -14,19 +14,19 @@
 
   <div class="details">
     {{- with .github -}}
-      <a class="item" href="https://github.com/{{- . | safeHTML -}}" target="_blank"><span class="iconfont icon-github"></span>&nbsp;{{- . -}}</a>
+      <a class="item" href="https://github.com/{{- . | safeHTML -}}" target="_blank" rel="noopener noreferrer"><span class="iconfont icon-github"></span>&nbsp;{{- . -}}</a>
     {{- end -}}
 
     {{- with .docker -}}
-      <a class="item" href="https://hub.docker.com/u/{{- . | safeHTML -}}" target="_blank"><span class="iconfont icon-docker"></span>&nbsp;{{- . -}}</a>
+      <a class="item" href="https://hub.docker.com/u/{{- . | safeHTML -}}" target="_blank" rel="noopener noreferrer"><span class="iconfont icon-docker"></span>&nbsp;{{- . -}}</a>
     {{- end -}}
 
     {{- with .twitter -}}
-      <a class="item" href="https://twitter.com/{{- . | safeHTML -}}" target="_blank"><span class="iconfont icon-twitter"></span>&nbsp;@{{- . -}}</a>
+      <a class="item" href="https://twitter.com/{{- . | safeHTML -}}" target="_blank" rel="noopener noreferrer"><span class="iconfont icon-twitter"></span>&nbsp;@{{- . -}}</a>
     {{- end -}}
     
     {{- with .email -}}
-      <a class="item" href="mailto:{{- . | safeHTML -}}" target="_blank"><span class="iconfont icon-email"></span>&nbsp;{{- . -}}</a>
+      <a class="item" href="mailto:{{- . | safeHTML -}}" target="_blank" rel="noopener noreferrer"><span class="iconfont icon-email"></span>&nbsp;{{- . -}}</a>
     {{- end -}}
   </div>
 </section>

--- a/layouts/partials/copyright.html
+++ b/layouts/partials/copyright.html
@@ -2,7 +2,7 @@
 <div class="footer-wrap">
     <p class="copyright">{{- $copyright -}}</p>
     <p class="powerby"><span>Powered&nbsp;by&nbsp;</span><a href="https://gohugo.io" 
-        target="_blank">Hugo</a><span>&nbsp;&amp;&nbsp;</span><a href="https://themes.gohugo.io/hugo-notepadium/" 
-        target="_blank">Notepadium</a></p>
+        target="_blank" rel="noopener noreferrer">Hugo</a><span>&nbsp;&amp;&nbsp;</span><a href="https://themes.gohugo.io/hugo-notepadium/" 
+        target="_blank" rel="noopener noreferrer">Notepadium</a></p>
     {{- partial "beian.html" . -}}
 </div>

--- a/layouts/partials/navigation-items.html
+++ b/layouts/partials/navigation-items.html
@@ -13,7 +13,7 @@
         {{- $url = $url | safeURL -}}
         {{- if strings.HasPrefix $url "/" -}}{{- $url = $url | relLangURL -}}{{- end -}}
         <a class="nav item" href="{{- $url -}}" 
-            {{- if strings.HasPrefix $url "http" -}}target="_blank"
+            {{- if strings.HasPrefix $url "http" -}}target="_blank" rel="noopener noreferrer"
             {{- end -}}>{{- .title -}}</a>
     {{- end -}}
 </nav></div>


### PR DESCRIPTION
Link with `target="_blank"` without `rel="noopener"` allows navigated site to access the page. This may cause security issue.
This PR adds the attributes and avoid this kind of vulnerability.