### PR TITLE
Making nested `<li>` styles more consistent

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -692,7 +692,7 @@ b {
 .article.markdown-body> :first-child,
 .article.markdown-body li> :first-child,
 .article.markdown-body blockquote> :first-child {
-  margin-top: 0;
+  margin-top: 20px;
 }
 
 .article.markdown-body> :last-child,


### PR DESCRIPTION
The first child of `<li>` should also have a `20px` margin-top.