### PR TITLE
Actually relative URLs when baseURL has a path component (e.g. http:/…

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <section id="header">
-    <div class="header wrap"><span class="header left-side"><a class="site home" href="{{- `/` | relLangURL -}}">
+    <div class="header wrap"><span class="header left-side"><a class="site home" href="{{- `` | relLangURL -}}">
                 {{- $logo := site.Params.logo -}}
                 {{- if $logo -}}
                 <img class="site logo" src="{{- $logo | relURL -}}" alt />

--- a/layouts/partials/navigation-items.html
+++ b/layouts/partials/navigation-items.html
@@ -2,10 +2,10 @@
 {{- if or $nav.showCategories $nav.showTags $nav.custom -}}
 <div class="nav wrap"><nav class="nav">
     {{- if $nav.showCategories -}}
-        <a class="nav item" href="{{- `/categories/` | relLangURL -}}">{{- T "Categories" -}}</a>
+        <a class="nav item" href="{{- `categories/` | relLangURL -}}">{{- T "Categories" -}}</a>
     {{- end -}}
     {{- if $nav.showTags -}}
-        <a class="nav item" href="{{- `/tags/` | relLangURL -}}">{{- T "Tags" -}}</a>
+        <a class="nav item" href="{{- `tags/` | relLangURL -}}">{{- T "Tags" -}}</a>
     {{- end -}}
     {{- range $nav.custom -}}
         {{- $url := replace .url "#" "%23" -}}

--- a/layouts/partials/note-labels.html
+++ b/layouts/partials/note-labels.html
@@ -3,13 +3,13 @@
         {{- range .Params.categories -}}
             {{- $category := replace . "#" "%23" -}}
             {{- $category = replace $category "." "%2e" -}}
-            {{- $url := print "/categories/" ($category | urlize) "/" -}}
+            {{- $url := print "categories/" ($category | urlize) "/" -}}
             <a class="category" href="{{- $url | relLangURL -}}">{{- . -}}</a>
         {{- end -}}
         {{- range .Params.tags -}}
             {{- $tag := replace . "#" "%23" -}}
             {{- $tag = replace $tag "." "%2e" -}}
-            {{- $url := print "/tags/" ($tag | urlize) "/" -}}
+            {{- $url := print "tags/" ($tag | urlize) "/" -}}
             <a class="tag" href="{{- $url | relLangURL -}}">{{- . -}}</a>
         {{- end -}}
     </p>


### PR DESCRIPTION
As stated in [this part of the Hugo documentation](https://gohugo.io/functions/rellangurl/#input-begins-with-a-slash), we need those paths without a leading slash.