### PR TITLE
Change relative links to absolute links

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,10 +309,10 @@ An example navigation-items.html:
 {{- if or $nav.showCategories $nav.showTags $nav.custom -}}
 <div class="nav wrap"><nav class="nav">
     {{- if $nav.showCategories -}}
-        <a class="nav item" href="{{- `/categories/` | relLangURL -}}">Categories</a>
+        <a class="nav item" href="{{- `/categories/` | absLangURL -}}">Categories</a>
     {{- end -}}
     {{- if $nav.showTags -}}
-        <a class="nav item" href="{{- `/tags/` | relLangURL -}}">Tags</a>
+        <a class="nav item" href="{{- `/tags/` | absLangURL -}}">Tags</a>
     {{- end -}}
     {{- range $nav.custom -}}
         {{- $url := .url | safeURL -}}
@@ -328,7 +328,7 @@ An example navigation-items.html:
 Or, you can rewrite it:
 
 ```html
-<a class="nav item" href="{{- `/pages/about/` | relURL -}}"><span class="iconfont icon-aboutus"></span>&nbsp;About</a>
+<a class="nav item" href="{{- `/pages/about/` | absURL -}}"><span class="iconfont icon-aboutus"></span>&nbsp;About</a>
 <a class="nav item" href="https://github.com/cntrump" target="_blank"><span class="iconfont icon-logo_github"></span>&nbsp;Github</a>
 ```
 

--- a/layouts/partials/article-author.html
+++ b/layouts/partials/article-author.html
@@ -6,7 +6,7 @@
 {{- with $profile -}}
 {{- if eq .enable true -}}
 <section class="article author">
-  {{- with .avatar -}}<img class="avatar" src="{{- . | relURL -}}" alt>{{- end -}}
+  {{- with .avatar -}}<img class="avatar" src="{{- . | absURL -}}" alt>{{- end -}}
   
   {{- with .name -}}<p class="name">{{- . -}}</p>{{- end -}}
   

--- a/layouts/partials/article-labels.html
+++ b/layouts/partials/article-labels.html
@@ -4,13 +4,13 @@
       {{- $category := replace . "#" "%23" -}}
       {{- $category = replace $category "." "%2e" -}}
       {{- $url := print "/categories/" ($category | urlize) "/" -}}
-      <a class="category" href={{- $url | relLangURL -}}>{{- . -}}</a>
+      <a class="category" href={{- $url | absLangURL -}}>{{- . -}}</a>
     {{- end -}}
     {{- range .Params.tags -}}
       {{- $tag := replace . "#" "%23" -}}
       {{- $tag = replace $tag "." "%2e" -}}
       {{- $url := print "/tags/" ($tag | urlize) "/" -}}
-      <a class="tag" href={{- $url | relLangURL -}}>{{- . -}}</a>
+      <a class="tag" href={{- $url | absLangURL -}}>{{- . -}}</a>
     {{- end -}}
 </section>
 {{- end -}}

--- a/layouts/partials/custom-js.html
+++ b/layouts/partials/custom-js.html
@@ -13,7 +13,7 @@
 {{- if ne $js "" -}}
   {{- $coreJS := slice $js ("" | resources.FromString "js/_core.js") | resources.Concat "js/core.js" -}}
   {{- $coreJS = $coreJS | resources.Minify | resources.Fingerprint "sha384" -}}
-  <script src="{{- $coreJS.RelPermalink -}}" integrity="{{- $coreJS.Data.Integrity -}}"></script>
+  <script src="{{- $coreJS.RelPermalink | absURL -}}" integrity="{{- $coreJS.Data.Integrity -}}"></script>
 {{- end -}}
 
 {{- partial "js.html" . -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <section id="header">
-    <div class="header wrap"><span class="header left-side"><a class="site home" href="{{- `/` | relLangURL -}}">
+    <div class="header wrap"><span class="header left-side"><a class="site home" href="{{- `/` | absLangURL -}}">
                 {{- $logo := site.Params.logo -}}
                 {{- if $logo -}}
                 <img class="site logo" src="{{- $logo | relURL -}}" alt />

--- a/layouts/partials/navigation-items.html
+++ b/layouts/partials/navigation-items.html
@@ -2,17 +2,17 @@
 {{- if or $nav.showCategories $nav.showTags $nav.custom -}}
 <div class="nav wrap"><nav class="nav">
     {{- if $nav.showCategories -}}
-        <a class="nav item" href="{{- `/categories/` | relLangURL -}}">{{- T "Categories" -}}</a>
+        <a class="nav item" href="{{- `/categories/` | absLangURL -}}">{{- T "Categories" -}}</a>
     {{- end -}}
     {{- if $nav.showTags -}}
-        <a class="nav item" href="{{- `/tags/` | relLangURL -}}">{{- T "Tags" -}}</a>
+        <a class="nav item" href="{{- `/tags/` | absLangURL -}}">{{- T "Tags" -}}</a>
     {{- end -}}
     {{- range $nav.custom -}}
         {{- $url := replace .url "#" "%23" -}}
         {{- $url = replace $url "." "%2e" -}}
         {{- $url = $url | safeURL -}}
         {{- if strings.HasPrefix $url "/" -}}{{- $url = $url | relLangURL -}}{{- end -}}
-        <a class="nav item" href="{{- $url -}}" 
+        <a class="nav item" href="{{- absURL $url -}}" 
             {{- if strings.HasPrefix $url "http" -}}target="_blank" rel="noopener noreferrer"
             {{- end -}}>{{- .title -}}</a>
     {{- end -}}

--- a/layouts/partials/note-labels.html
+++ b/layouts/partials/note-labels.html
@@ -4,13 +4,13 @@
             {{- $category := replace . "#" "%23" -}}
             {{- $category = replace $category "." "%2e" -}}
             {{- $url := print "/categories/" ($category | urlize) "/" -}}
-            <a class="category" href="{{- $url | relLangURL -}}">{{- . -}}</a>
+            <a class="category" href="{{- $url | absLangURL -}}">{{- . -}}</a>
         {{- end -}}
         {{- range .Params.tags -}}
             {{- $tag := replace . "#" "%23" -}}
             {{- $tag = replace $tag "." "%2e" -}}
             {{- $url := print "/tags/" ($tag | urlize) "/" -}}
-            <a class="tag" href="{{- $url | relLangURL -}}">{{- . -}}</a>
+            <a class="tag" href="{{- $url | absLangURL -}}">{{- . -}}</a>
         {{- end -}}
     </p>
 {{- end -}}

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -78,4 +78,4 @@
 {{- $coreCSS = slice $coreCSS ("" | resources.FromString "css/_core.css") | resources.Concat "css/core.css" -}}
 {{- $coreCSS = $coreCSS | resources.Minify | resources.Fingerprint "sha384" -}}
 
-<link rel="stylesheet" href="{{- $coreCSS.RelPermalink -}}" integrity="{{- $coreCSS.Data.Integrity -}}">
+<link rel="stylesheet" href="{{- $coreCSS.RelPermalink | absURL -}}" integrity="{{- $coreCSS.Data.Integrity -}}">


### PR DESCRIPTION
Changed because when accessing a non-existent `https://example.com/post/hello-world/`, relative links starting with `./`, which is not present, the relative link is not rendered correctly and the link does not work.