### PR TITLE
Support external post URLs

### DIFF
--- a/layouts/partials/note-list.html
+++ b/layouts/partials/note-list.html
@@ -7,8 +7,13 @@
     {{- range $paginator.Pages -}}
       {{- $relURL := replace .RelPermalink "#" "%23" -}}
       {{- $relURL = replace $relURL "." "%2e" -}}
-    <li class="item"><a class="note" href="{{- $relURL -}}">
-            <p class="note title">{{- .Title | safeHTML -}}</p>
+    <li class="item">
+        {{ if .Params.external }}
+        <a class="note" href="{{- .Params.externalUrl -}}">
+        {{else}}
+        <a class="note" href="{{- $relURL -}}">
+        {{end}}
+            <p class="note title">{{- .Title | safeHTML -}} {{ if .Params.external }} ⇗{{end}}</p>
             {{- if .Date -}}
                 <p class="note date">{{- .Date.Format $dateFormat -}}</p>
             {{- end -}}


### PR DESCRIPTION
I have a few blog posts on my own blog, and a few blog posts on other blogs. It's nice to be able to link to the latter in my own blog's list of posts.

This allows doing this by introducing `external` (boolean) and `externalUrl` (string) parameters that can be added to the top of a post. If `external` is true, tapping on the preview navigates directly to the `externalUrl`. It also adds ` ⇗` to the end of the preview title, to indicate to readers that the link is external.

The preview still supports showing the title and body text of the local post.