### PR TITLE
Fix Google Analytics

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,5 +7,5 @@
 </section>
 {{- partial "math.html" . -}}
 {{- partial "syntax.html" . -}}
-{{- template "_internal/google_analytics_async.html" . -}}
+{{- template "_internal/google_analytics.html" . -}}
 {{- partial "custom-js.html" . -}}


### PR DESCRIPTION
`google_analytics_async` was deprecated, see
https://gohugo.io/templates/embedded/#google-analytics
https://discourse.gohugo.io/t/build-error-on-v0-125-2-calling-internal-template-internal-google-analytics-async-html/49410