### PR TITLE
Fix Disqus and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ hasCJKLanguage = true
 
 enableRobotsTXT = true
 
-# Enable Disqus
-#disqusShortname = "XXX"
+# [services.disqus]
+# shortname = '' # Disqus shortname
 
-# Google Analytics
-#googleAnalytics = "UA-123-45"
+# [services.googleAnalytics]
+# id = '' # Google tag ID
 
 [markup.highlight]
 codeFences = true
@@ -209,7 +209,8 @@ Setup Disqus [shortname](https://help.disqus.com/en/articles/1717111-what-s-a-sh
 
 ```toml
 # disqus
-disqusShortname = "XXX"  # your short name
+[services.disqus]
+shortname = '' # your short name
 
 [params.comments]
 enable = false  # En/Disable comments globally, default: false. You can always enable comments on per page.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -13,11 +13,11 @@ enableRobotsTXT = true
 # Enable relativeURLs if your site hosted on GitHub.io
 #relativeURLs = true
 
-# Enable Disqus
-#disqusShortname = "XXX"
+# [services.disqus]
+# shortname = '' # Disqus shortname
 
-# Google Analytics
-#googleAnalytics = "UA-123-45"
+# [services.googleAnalytics]
+# id = '' # Google tag ID
 
 ignoreErrors = ["error-remote-getjson"]
 

--- a/layouts/partials/article-comments.html
+++ b/layouts/partials/article-comments.html
@@ -1,6 +1,6 @@
 {{- if or (eq .Params.comments true) (and (ne .Params.comments false) (eq site.Params.comments.enable true)) -}}
     <section class="article discussion">
-    {{- if gt (len site.DisqusShortname) 0 -}}
+    {{- if gt (len site.Config.Services.Disqus.Shortname) 0 -}}
         {{- template "_internal/disqus.html" . -}}
     {{- else if ne site.Params.comments.utterances.repo "" -}}
         <script 


### PR DESCRIPTION
`site.DisqusShortname` and `site.GoogleAnalytics` were deprecated in [v0.120.0](https://github.com/gohugoio/hugo/releases/tag/v0.120.0), see https://gohugo.io/methods/site/disqusshortname/ and https://gohugo.io/methods/site/googleanalytics/